### PR TITLE
Evaluated arguments

### DIFF
--- a/autodrp/_baking.py
+++ b/autodrp/_baking.py
@@ -1,0 +1,86 @@
+ALWAYS_TRUE = lambda *args, **kwargs: True
+
+class CheckPermissions:
+    def __init__(self, *checks):
+        self.checks = checks
+    
+    def __call__(self, request):
+        for permission in self.checks:
+            if permission.has_permission(request):
+                return True
+        return False
+
+class CheckObjectPermissions:
+    def __init__(self, *checks):
+        self.checks = checks
+    
+    def __call__(self, obj, request):
+        for permission in self.checks:
+            if permission.has_object_permission(request, obj):
+                return True
+        return False
+
+class Filter:
+    def __init__(self, *checks):
+        self.checks = checks
+    
+    def __call__(self, request, queryset):
+        for filter in self.checks:
+            if hasattr(filter, 'has_permission') and not filter.has_permission(request):
+                continue
+
+            queryset, filtered = filter.filter(request, queryset)
+            
+            if filtered:
+                break
+        
+        return queryset
+
+def _bake_global_permissions(sender, permission_data):
+    for actions, check_data in permission_data.items():
+        if not hasattr(check_data, '__iter__'):
+            check_data = [check_data]
+        
+        checks = [check for check in check_data if hasattr(check, 'has_permission')]
+        actions = [actions] if isinstance(actions, str) else actions
+
+        if len(checks) > 0:
+            permission_function = staticmethod(CheckPermissions(*checks))
+        else:
+            permission_function = staticmethod(ALWAYS_TRUE)
+
+        for action in actions:
+            setattr(sender, f'has_{action}_permission', permission_function)
+
+def _bake_object_permissions(sender, permission_data):
+    for actions, check_data in permission_data.items():
+        if not hasattr(check_data, '__iter__') and not isinstance(check_data, str):
+            check_data = [check_data]
+        
+        checks = [check for check in check_data if hasattr(check, 'has_object_permission')]
+        filters = [check for check in check_data if hasattr(check, 'filter')]
+        actions = [actions] if isinstance(actions, str) else actions
+
+        if len(checks) > 0:
+            permission_function = CheckPermissions(*checks)
+        else:
+            permission_function = ALWAYS_TRUE
+
+        for action in actions:
+            setattr(sender, f'has_object_{action}_permission', permission_function)
+        
+        if len(filters) > 0:
+            filter_function = staticmethod(Filter(*filters))
+            for action in actions:
+                setattr(sender, f'filter_for_{action}', filter_function)
+
+def bake_permissions(sender):
+    if hasattr(sender, '_bake_permission_data'):
+        _bake_global_permissions(sender, sender._bake_permission_data())
+    elif hasattr(sender, 'DRY_GLOBAL_PERMISSIONS'):
+        _bake_global_permissions(sender, sender.DRY_GLOBAL_PERMISSIONS)
+
+    if hasattr(sender, '_bake_object_permission_data'):
+        _bake_object_permissions(sender, sender._bake_object_permission_data())
+    elif hasattr(sender, 'DRY_OBJECT_PERMISSIONS'):
+        _bake_object_permissions(sender, sender.DRY_OBJECT_PERMISSIONS)

--- a/autodrp/apps.py
+++ b/autodrp/apps.py
@@ -1,7 +1,7 @@
 import django.apps
 from django.apps import AppConfig
 
-from autodrp.utils import bake_permissions
+from ._baking import bake_permissions
 
 
 class AutoDRPConfig(AppConfig):

--- a/autodrp/checks.py
+++ b/autodrp/checks.py
@@ -58,6 +58,16 @@ class ModelAttributeCheck:
             queryset, filtered = _filter.filter(request, queryset)
         return queryset, True
 
+class QueryBuilderCheck:
+    def __init__(self, query_builder):
+        self.query_builder = query_builder
+
+    def has_permission(self, request):
+        return True
+    
+    def filter(self, request, queryset):
+        return queryset.filter(self.query_builder.build(request=request))
+
 class IsAuthenticated:
     def __init__(self, filter=None):
         self._filter = filter

--- a/autodrp/utils.py
+++ b/autodrp/utils.py
@@ -1,5 +1,7 @@
 from django.db.models import Q
 
+from .checks import QueryBuilderCheck
+
 
 class EvalArgument:
     def __init__(self, eval_string, *required_keywords):
@@ -136,6 +138,9 @@ class QueryBuilder:
     def filter_against(self, queryset, **kwargs):
         q_obj = self.build(**kwargs)
         return queryset.filter(q_obj)
+    
+    def to_check(self):
+        return QueryBuilderCheck(self)
 
 class filter_keyword_args:
     def __init__(self, function, *keywords):

--- a/autodrp/utils.py
+++ b/autodrp/utils.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from functools import wraps
+import inspect
 
 from .checks import QueryBuilderCheck
 
@@ -17,61 +19,65 @@ class EvalArgument:
         self._validate_kwargs(kwargs)
         return eval(self._compiled_eval, globals={}, locals=kwargs)
 
+def _compile_and(q_obj=None, compiled_q=None, **kwargs):
+    if not compiled_q:
+        compiled_q = Q(**kwargs)
+
+    if q_obj:
+        return q_obj & compiled_q
+    return compiled_q
+
+def _compile_and_not(q_obj=None, compiled_q=None, **kwargs):
+    if not compiled_q:
+        compiled_q = Q(**kwargs)
+
+    if q_obj:
+        return q_obj & ~compiled_q
+    return compiled_q
+
+def _compile_or(q_obj=None, compiled_q=None, **kwargs):
+    if not compiled_q:
+        compiled_q = Q(**kwargs)
+
+    if q_obj:
+        return q_obj | compiled_q
+    return compiled_q
+
+def _compile_or_not(q_obj=None, compiled_q=None, **kwargs):
+    if not compiled_q:
+        compiled_q = ~Q(**kwargs)
+
+    if q_obj:
+        return q_obj | compiled_q
+    return compiled_q
+
+def _compile_xor(q_obj=None, compiled_q=None, **kwargs):
+    if not compiled_q:
+        arg1, arg2 = kwargs.items()
+        arg1, arg2 = {arg1[0]: arg1[1]}, {arg2[0]: arg2[1]}
+        compiled_q = (Q(**arg1) and ~Q(**arg2)) | (Q(**arg2) and ~Q(**arg1))
+
+    if q_obj:
+        return q_obj & compiled_q
+
+    return compiled_q
+
+def _compile_args(operation_kwargs, **kwargs):
+    compiled_kwargs = {key: value if not callable(value) else value(**kwargs) for key, value in operation_kwargs.items()}
+    return compiled_kwargs
+
 class QueryBuilder:
     @staticmethod
     def where(**kwargs):
         return QueryBuilder().and_where(**kwargs)
+    
+    @staticmethod
+    def where_not(**kwargs):
+        return QueryBuilder().and_not_where(**kwargs)
 
     def __init__(self):
         self._query = []
         self._cached_q = None
-
-    def _compile_and(q_obj=None, compiled_q=None, **kwargs):
-        if not compiled_q:
-            compiled_q = Q(**kwargs)
-
-        if q_obj:
-            return q_obj & compiled_q
-        return compiled_q
-
-    def _compile_and_not(q_obj=None, compiled_q=None, **kwargs):
-        if not compiled_q:
-            compiled_q = Q(**kwargs)
-
-        if q_obj:
-            return q_obj & ~compiled_q
-        return compiled_q
-
-    def _compile_or(q_obj=None, compiled_q=None, **kwargs):
-        if not compiled_q:
-            compiled_q = Q(**kwargs)
-
-        if q_obj:
-            return q_obj | compiled_q
-        return compiled_q
-
-    def _compile_or_not(q_obj=None, compiled_q=None, **kwargs):
-        if not compiled_q:
-            compiled_q = ~Q(**kwargs)
-
-        if q_obj:
-            return q_obj | compiled_q
-        return compiled_q
-    
-    def _compile_xor(q_obj=None, compiled_q=None, **kwargs):
-        if not compiled_q:
-            arg1, arg2 = kwargs.items()
-            arg1, arg2 = {arg1[0]: arg1[1]}, {arg2[0]: arg2[1]}
-            compiled_q = (Q(**arg1) and ~Q(**arg2)) | (Q(**arg2) and ~Q(**arg1))
-
-        if q_obj:
-            return q_obj & compiled_q
-
-        return compiled_q
-    
-    def _compile_args(self, operation_kwargs, **kwargs):
-        compiled_kwargs = {key: value if not callable(value) else value(**kwargs) for key, value in operation_kwargs.items()}
-        return compiled_kwargs
 
     def _add_operation(self, operation, **kwargs):
         if not any(callable(value) for value in kwargs.values()):
@@ -89,25 +95,25 @@ class QueryBuilder:
         })
      
     def and_where(self, **kwargs):
-        self._add_operation(self._compile_and, **kwargs)
+        self._add_operation(_compile_and, **kwargs)
         return self
 
     def and_not_where(self, **kwargs):
-        self._add_operation(self._compile_and_not, **kwargs)
+        self._add_operation(_compile_and_not, **kwargs)
         return self
         
     def or_where(self, **kwargs):
-        self._add_operation(self._compile_or, **kwargs)
+        self._add_operation(_compile_or, **kwargs)
         return self
     
     def or_not_where(self, **kwargs):
-        self._add_operation(self._compile_or_not, **kwargs)
+        self._add_operation(_compile_or_not, **kwargs)
         return self
     
     def where_one_not_both(self, **kwargs):
         if len(kwargs) != 2:
             raise Exception('XOR requires ONLY a left and right operand (2 keyword arguments required)')
-        self._add_operation(self._compile_xor, **kwargs)
+        self._add_operation(_compile_xor, **kwargs)
         return self
     
     def build(self, do_cache=False, ignore_cache=False, **kwargs):
@@ -123,7 +129,7 @@ class QueryBuilder:
 
             if not compiled_q:
                 should_cache = False
-                op_kwargs = self._compile_args(**kwargs)
+                op_kwargs = _compile_args(**kwargs)
                 if len(op_kwargs) == 0 and operation['ignore_none_args']:
                     continue
                 q_obj = operation_func(q_obj=q_obj, **op_kwargs)
@@ -143,20 +149,52 @@ class QueryBuilder:
         return QueryBuilderCheck(self)
 
 class filter_keyword_args:
-    def __init__(self, function, *keywords):
-        self.function = function
-        self.keywords = keywords
-        self.keyword_count = len(keywords)
+    def __init__(self):
+        self._function_signature = None
     
-    def __call__(self, *args, **kwargs):
-        if len(kwargs) == 0 and len(args) == self.keyword_count:
-            return self.function(*args)
+    def _parse_args(self, *args, **kwargs):
+        if self.accepts_var_args:
+            required_args = args[0:self.required_args]
+            var_args = args[self.required_args:]
+        else:
+            args_passed = len(args)
+            if args_passed != self.required_args:
+                raise Exception(f'Method requires exactly {self.required_args} arguments ({args_passed} arguments were used)')
+            required_args = args
+            var_args = []
 
-        values = []
-        for key in self.keywords:
-            value = kwargs.get(key)
-            if not value:
-                raise Exception(f'Missing keyword argument {key}.')
-            values.append(value)
+        missing_kwargs = []
+        for keyword in self.required_keywords:
+            if keyword not in kwargs:
+                missing_kwargs.append(keyword)
         
-        return self.function(*values)
+        if missing_kwargs:
+            raise Exception(f'Method requires the keywords {", ".join(self.required_keywords)} arguments ({", ".join(missing_kwargs)} are missing)')
+
+        if self.accepts_var_kwargs:
+            accepted_kwargs = kwargs
+        else:
+            accepted_kwargs = {key: kwargs[key] for key in self.required_keywords}
+
+        return required_args, var_args, accepted_kwargs
+
+    def __call__(self, func):
+        self._function_signature = inspect.signature(func)
+
+        @wraps(func)
+        def wrapped_function(*args, **kwargs):
+            if any(param.kind == param.VAR_KEYWORD for param in self._function_signature.parameters.values()):
+                bound_args = self._function_signature.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                return func(**bound_args.arguments)
+            else:
+                kwargs = {
+                    param_name: kwargs[param_name]
+                    for param_name, param in self._function_signature.parameters.items() if (
+                        param.kind is param.KEYWORD_ONLY or
+                        param.kind is param.POSITIONAL_OR_KEYWORD
+                    ) and
+                    param_name in kwargs
+                }
+                return func(*args, **kwargs)
+        return wrapped_function

--- a/autodrp/utils.py
+++ b/autodrp/utils.py
@@ -1,89 +1,157 @@
-from django.db.models.signals import class_prepared
-from django.dispatch import receiver
+from django.db.models import Q
 
-ALWAYS_TRUE = lambda *args, **kwargs: True
 
-class CheckPermissions:
-    def __init__(self, *checks):
-        self.checks = checks
+class EvalArgument:
+    def __init__(self, eval_string, *required_keywords):
+        self._compiled_eval = compile(f'return {eval_string}', '<string>', 'eval')
+        self.required_keywords = required_keywords
     
-    def __call__(self, request):
-        for permission in self.checks:
-            if permission.has_permission(request):
-                return True
-        return False
+    def _validate_kwargs(self, kwargs):
+        for keyword in self.required_keywords:
+            if keyword not in kwargs:
+                raise Exception(f'Missing keyword argument {keyword}.')
 
-class CheckObjectPermissions:
-    def __init__(self, *checks):
-        self.checks = checks
+    def __call__(self, **kwargs):
+        self._validate_kwargs(kwargs)
+        return eval(self._compiled_eval, globals={}, locals=kwargs)
+
+class QueryBuilder:
+    @staticmethod
+    def where(**kwargs):
+        return QueryBuilder().and_where(**kwargs)
+
+    def __init__(self):
+        self._query = []
+        self._cached_q = None
+
+    def _compile_and(q_obj=None, compiled_q=None, **kwargs):
+        if not compiled_q:
+            compiled_q = Q(**kwargs)
+
+        if q_obj:
+            return q_obj & compiled_q
+        return compiled_q
+
+    def _compile_and_not(q_obj=None, compiled_q=None, **kwargs):
+        if not compiled_q:
+            compiled_q = Q(**kwargs)
+
+        if q_obj:
+            return q_obj & ~compiled_q
+        return compiled_q
+
+    def _compile_or(q_obj=None, compiled_q=None, **kwargs):
+        if not compiled_q:
+            compiled_q = Q(**kwargs)
+
+        if q_obj:
+            return q_obj | compiled_q
+        return compiled_q
+
+    def _compile_or_not(q_obj=None, compiled_q=None, **kwargs):
+        if not compiled_q:
+            compiled_q = ~Q(**kwargs)
+
+        if q_obj:
+            return q_obj | compiled_q
+        return compiled_q
     
-    def __call__(self, obj, request):
-        for permission in self.checks:
-            if permission.has_object_permission(request, obj):
-                return True
-        return False
+    def _compile_xor(q_obj=None, compiled_q=None, **kwargs):
+        if not compiled_q:
+            arg1, arg2 = kwargs.items()
+            arg1, arg2 = {arg1[0]: arg1[1]}, {arg2[0]: arg2[1]}
+            compiled_q = (Q(**arg1) and ~Q(**arg2)) | (Q(**arg2) and ~Q(**arg1))
 
-class Filter:
-    def __init__(self, *checks):
-        self.checks = checks
+        if q_obj:
+            return q_obj & compiled_q
+
+        return compiled_q
     
-    def __call__(self, request, queryset):
-        for filter in self.checks:
-            if hasattr(filter, 'has_permission') and not filter.has_permission(request):
-                continue
+    def _compile_args(self, operation_kwargs, **kwargs):
+        compiled_kwargs = {key: value if not callable(value) else value(**kwargs) for key, value in operation_kwargs.items()}
+        return compiled_kwargs
 
-            queryset, filtered = filter.filter(request, queryset)
-            
-            if filtered:
-                break
+    def _add_operation(self, operation, **kwargs):
+        if not any(callable(value) for value in kwargs.values()):
+            self._query.append({
+                'operation': operation,
+                'cached': operation(**kwargs)
+            })
+            return
+
+        ignore_no_args_eval = kwargs.pop('ignore_no_args_eval', False)
+        self._query.append({
+            'operand': operation,
+            'ignore_none_args': ignore_no_args_eval,
+            'kwargs': kwargs
+        })
+     
+    def and_where(self, **kwargs):
+        self._add_operation(self._compile_and, **kwargs)
+        return self
+
+    def and_not_where(self, **kwargs):
+        self._add_operation(self._compile_and_not, **kwargs)
+        return self
         
-        return queryset
+    def or_where(self, **kwargs):
+        self._add_operation(self._compile_or, **kwargs)
+        return self
+    
+    def or_not_where(self, **kwargs):
+        self._add_operation(self._compile_or_not, **kwargs)
+        return self
+    
+    def where_one_not_both(self, **kwargs):
+        if len(kwargs) != 2:
+            raise Exception('XOR requires ONLY a left and right operand (2 keyword arguments required)')
+        self._add_operation(self._compile_xor, **kwargs)
+        return self
+    
+    def build(self, do_cache=False, ignore_cache=False, **kwargs):
+        if self._cached_q and not ignore_cache:
+            return self._cached_q
 
-def _bake_global_permissions(sender, permission_data):
-    for actions, check_data in permission_data.items():
-        if not hasattr(check_data, '__iter__'):
-            check_data = [check_data]
+        should_cache = True
+        q_obj = None
+
+        for operation in self._query:
+            operation_func = operation['operation']
+            compiled_q = operation.get('cached')
+
+            if not compiled_q:
+                should_cache = False
+                op_kwargs = self._compile_args(**kwargs)
+                if len(op_kwargs) == 0 and operation['ignore_none_args']:
+                    continue
+                q_obj = operation_func(q_obj=q_obj, **op_kwargs)
+            else:
+                q_obj = operation_func(q_obj=q_obj, compiled_q=compiled_q)
         
-        checks = [check for check in check_data if hasattr(check, 'has_permission')]
-        actions = [actions] if isinstance(actions, str) else actions
+        if should_cache or do_cache:
+            self._cached_q = q_obj
 
-        if len(checks) > 0:
-            permission_function = staticmethod(CheckPermissions(*checks))
-        else:
-            permission_function = staticmethod(ALWAYS_TRUE)
+        return q_obj
+    
+    def filter_against(self, queryset, **kwargs):
+        q_obj = self.build(**kwargs)
+        return queryset.filter(q_obj)
 
-        for action in actions:
-            setattr(sender, f'has_{action}_permission', permission_function)
+class filter_keyword_args:
+    def __init__(self, function, *keywords):
+        self.function = function
+        self.keywords = keywords
+        self.keyword_count = len(keywords)
+    
+    def __call__(self, *args, **kwargs):
+        if len(kwargs) == 0 and len(args) == self.keyword_count:
+            return self.function(*args)
 
-def _bake_object_permissions(sender, permission_data):
-    for actions, check_data in permission_data.items():
-        if not hasattr(check_data, '__iter__') and not isinstance(check_data, str):
-            check_data = [check_data]
+        values = []
+        for key in self.keywords:
+            value = kwargs.get(key)
+            if not value:
+                raise Exception(f'Missing keyword argument {key}.')
+            values.append(value)
         
-        checks = [check for check in check_data if hasattr(check, 'has_object_permission')]
-        filters = [check for check in check_data if hasattr(check, 'filter')]
-        actions = [actions] if isinstance(actions, str) else actions
-
-        if len(checks) > 0:
-            permission_function = CheckPermissions(*checks)
-        else:
-            permission_function = ALWAYS_TRUE
-
-        for action in actions:
-            setattr(sender, f'has_object_{action}_permission', permission_function)
-        
-        if len(filters) > 0:
-            filter_function = staticmethod(Filter(*filters))
-            for action in actions:
-                setattr(sender, f'filter_for_{action}', filter_function)
-
-def bake_permissions(sender):
-    if hasattr(sender, '_bake_permission_data'):
-        _bake_global_permissions(sender, sender._bake_permission_data())
-    elif hasattr(sender, 'DRY_GLOBAL_PERMISSIONS'):
-        _bake_global_permissions(sender, sender.DRY_GLOBAL_PERMISSIONS)
-
-    if hasattr(sender, '_bake_object_permission_data'):
-        _bake_object_permissions(sender, sender._bake_object_permission_data())
-    elif hasattr(sender, 'DRY_OBJECT_PERMISSIONS'):
-        _bake_object_permissions(sender, sender.DRY_OBJECT_PERMISSIONS)
+        return self.function(*values)


### PR DESCRIPTION
This changes the following:
- The previous `autodrp.utils` was renamed.
    - It was intended for internal use only, given that the functionality inside was not documented.
- Added `autodrp.utils`
    -  A class named `EvalArgument` was added
         - This class takes an argument that compiles, along with arguments for what parameters are expected
         - This class can be used with `ModelAttributeCheck` or the new `QueryBuilder` class
         - `ModelAttributeCheck` only passes in one argument: `request`. If you opt to require arguments, only require `request`.
    - Added `QueryBuilder` class, which allows chaining and building a `Q` object with its `build` method, which takes key-word arguments
    - Added `filter_keyword_args` decorator
         - This decorator ignores extra keywords passed in if the function doesn't take variable key-word arguments
-  Added `QueryBuilderCheck` to `autodrp.checks`
    - The constructor accepts one argument, which is a `QueryBuilder`
    - It is recommended to use the `QueryBuilder` method `to_check` to return a check, instead of initializing a `QueryBuilderCheck` manually

To put it all together, let's assume you have a model named Project that has the field `owner`, which is a foreign key to Django's `User` model.
```python
     DRY_GLOBAL_PERMISSIONS = {
          'read': True,
          'write':  QueryBuilder.where(
               owner=EvalArgument('request.user', 'request')
          ).to_check()
     }
```
This example would only let you write to a project if you are the owner. That example is like doing the following via the current implementation:
```python
def get_user(request):
     return request.user

...

     DRY_GLOBAL_PERMISSIONS = {
          'read': True,
          'write':  ModelAttributeCheck(owner=get_user)
     }
```
Furthermore, you can also do the following:
```python
     DRY_GLOBAL_PERMISSIONS = {
          'read': True,
          'write':  ModelAttributeCheck(owner=EvalArgument('request.user', 'request'))
     }
```
Or possibly even:
```python
def get_user_query(request):
     return QueryBuilder.where(
          owner=request.user
     ).build()

...

     DRY_GLOBAL_PERMISSIONS = {
          'read': True,
          'write':  ModelAttributeCheck(get_user_query)
     }
```
Or if you want to go crazy:
```python
USER_QUERY = QueryBuilder.where(owner=lambda request: request.user)

def get_user_query(request):
     return USER_QUERY.build(request=request)

...

     DRY_GLOBAL_PERMISSIONS = {
          'read': True,
          'write':  ModelAttributeCheck(get_user_query)
     }
```
Ultimately, there are several ways to accomplish the same task (with more possibilities not listed). Some of these methods may prove more or less efficient, depending on your use case. `QueryBuilder` can be used independently, without requiring use of other AutoDRP features.

For `QueryBuilderCheck` will be more efficient than `ModelAttributeCheck` if all arguments used are static. Furthermore, it may be more efficient to use than passing in a function that constucts a Q object to `ModelAttributeCheck`.

As for `filter_keyword_args`, this is how it functions:
```python
@filter_keyword_args()
def get_user(request):
     return request.user

# Functions normally
user = get_user(some_request)

projects = QueryBuilder.where(
     owner=get_user
).filter_against(Project.objects.all(), not_request=some_request) # Throws exception, since request isn't passed in as a key-word argument
```
There may be some use cases where functionality like this would be helpful, such as writing a utility function to get a user and using that same function in `QueryBuilder` or `ModelAttributeCheck`. Additional arguments could be passed in and ignored.